### PR TITLE
更新不再依赖 PyPI 上不存在的 pyncm 包；，改为直接从 GitCode 镜像仓库克隆源码安装。

### DIFF
--- a/.github/workflows/auto_score.yml
+++ b/.github/workflows/auto_score.yml
@@ -2,7 +2,7 @@ name: Auto Score
 
 on:
   schedule:
-    - cron: '0 17 * * *'  # UTC 17:00 (北京时间1:00)
+    - cron: '0 17 * * *'
   workflow_dispatch:
 
 jobs:
@@ -15,11 +15,16 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.11'   # 建议固定版本
     
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        
+        # 1. 先从 GitHub 安装 pyncm 的 v1.7.1（携带正确版本号）
+        pip install git+https://${{ secrets.GITHUB_TOKEN }}@github.com/mos9527/pyncm.git@v1.7.1
+        
+        # 2. 再安装 requirements.txt 里的其他依赖（pyncm 已满足，不会报错）
         pip install -r requirements.txt
     
     - name: Run script
@@ -34,4 +39,4 @@ jobs:
         WAIT_TIME_MAX: ${{ secrets.WAIT_TIME_MAX }}
         SCORE: ${{ secrets.SCORE }}
         FULL_EXTRA_TASKS: ${{ secrets.FULL_EXTRA_TASKS }}
-      run: python main.py 
+      run: python main.py

--- a/.github/workflows/auto_score.yml
+++ b/.github/workflows/auto_score.yml
@@ -2,7 +2,7 @@ name: Auto Score
 
 on:
   schedule:
-    - cron: '0 17 * * *'
+    - cron: '0 17 * * *'  # UTC 17:00 (北京时间1:00)
   workflow_dispatch:
 
 jobs:
@@ -15,16 +15,11 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11'   # 建议固定版本
+        python-version: '3.x'
     
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        
-        # 1. 先从 GitHub 安装 pyncm 的 v1.7.1（携带正确版本号）
-        pip install git+https://${{ secrets.GITHUB_TOKEN }}@github.com/mos9527/pyncm.git@v1.7.1
-        
-        # 2. 再安装 requirements.txt 里的其他依赖（pyncm 已满足，不会报错）
         pip install -r requirements.txt
     
     - name: Run script

--- a/.github/workflows/auto_score.yml
+++ b/.github/workflows/auto_score.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5   # 更新到 v5
       with:
-        python-version: '3.9'
+        python-version: '3.x'
     
     - name: Install dependencies
       run: |

--- a/.github/workflows/auto_score.yml
+++ b/.github/workflows/auto_score.yml
@@ -10,17 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    # 更新到 v4 以避免 Node.js 警告（可选但推荐）
+    - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5   # 更新到 v5
       with:
         python-version: '3.9'
     
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        
+        # 1. 安装 requirements.txt 中的其他依赖（不含 pyncm）
         pip install -r requirements.txt
+        
+        # 2. 从 GitCode 镜像安装 pyncm（原 GitHub 仓库已消失）
+        pip install git+https://gitcode.com/gh_mirrors/py/pyncm.git
     
     - name: Run script
       env:

--- a/.github/workflows/auto_score.yml
+++ b/.github/workflows/auto_score.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9'
     
     - name: Install dependencies
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.25.0
 pycryptodome>=3.9.0
 PyNaCl>=1.4.0
-pyncm~=1.7.1
+pyncm~=1.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests>=2.25.0
 pycryptodome>=3.9.0
 PyNaCl>=1.4.0
-pyncm==1.6.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.25.0
 pycryptodome>=3.9.0
 PyNaCl>=1.4.0
-pyncm~=1.7.1
+pyncm~=1.6.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.25.0
 pycryptodome>=3.9.0
 PyNaCl>=1.4.0
-git+https://github.com/mos9527/pyncm.git@v1.7.1
+pyncm~=1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.25.0
 pycryptodome>=3.9.0
 PyNaCl>=1.4.0
-pyncm~=1.6.8.0
+pyncm==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.25.0
 pycryptodome>=3.9.0
 PyNaCl>=1.4.0
-pyncm~=1.7.1
+git+https://github.com/mos9527/pyncm.git@v1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.25.0
 pycryptodome>=3.9.0
 PyNaCl>=1.4.0
-pyncm~=1.8.1
+pyncm~=1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.25.0
 pycryptodome>=3.9.0
 PyNaCl>=1.4.0
-pyncm==1.7.1
+pyncm==1.6.8


### PR DESCRIPTION
不再依赖 PyPI 上不存在的 pyncm 包；，改为直接从 GitCode 镜像仓库克隆源码安装。