### PR TITLE
不再依赖 PyPI 上不存在的 pyncm 包；，改为直接从 GitCode 镜像仓库克隆源码安装。

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests>=2.25.0
 pycryptodome>=3.9.0
 PyNaCl>=1.4.0
-pyncm~=1.7.1


### PR DESCRIPTION
不再依赖 PyPI 上不存在的 pyncm 包；，改为直接从 GitCode 镜像仓库克隆源码安装。