### PR TITLE
fix: replace pyncm with lmc2007/pyncmfork to resolve PyPI package removal

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.25.0
 pycryptodome>=3.9.0
 PyNaCl>=1.4.0
-pyncm~=1.7.1
+git+https://github.com/lmc2007/pyncmfork.git


### PR DESCRIPTION
- Replace 'pyncm~=1.7.1' (removed from PyPI) with 'git+https://github.com/lmc2007/pyncmfork.git'
- Fixes issue #29: pyncm dependency installation failure
- Reference: https://github.com/ACAne0320/ncmp/issues/29#issuecomment-4363787572